### PR TITLE
Cleanup commented-out logic for issue #28

### DIFF
--- a/app/modes/chapter/routes.py
+++ b/app/modes/chapter/routes.py
@@ -233,16 +233,6 @@ def learn_topic(topic_name, step_index):
 
     plan_steps = topic_data.get('plan', [])
 
-    # If topic has no plan (quiz/flashcard only), redirect
-    # Not needed after issue #28 is fixed, but keeping the commented logic for now
-    # if not plan_steps:
-    #     # Checking logic from app.py
-    #     if 'flashcards' in topic_data and topic_data['flashcards']:
-    #         return redirect(url_for('flashcard.mode', topic_name=topic_name)) # Adjusted endpoint name
-    #     elif 'quiz' in topic_data:
-    # return redirect(url_for('quiz.mode', topic_name=topic_name)) # Adjusted
-    # endpoint name
-
     if not 0 <= step_index < len(plan_steps):
         return "Invalid step index", 404
 

--- a/tests/test_chapter_plan_handling.py
+++ b/tests/test_chapter_plan_handling.py
@@ -1,0 +1,62 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Mark all tests in this file as 'unit'
+pytestmark = pytest.mark.unit
+
+def test_chapter_mode_no_plan_direct_access(auth_client, mocker, logger):
+    """Test accessing chapter learn mode directly when no plan exists."""
+    logger.section("test_chapter_mode_no_plan_direct_access")
+    topic_name = "flashcard_only_topic"
+
+    # Topic data with flashcards but no plan
+    topic_data = {
+        "name": topic_name,
+        "plan": [],
+        "chapter_mode": [],
+        "flashcard_mode": [{"term": "Foo", "definition": "Bar"}]
+    }
+
+    mocker.patch('app.modes.chapter.routes.load_topic', return_value=topic_data)
+
+    # 1. Accessing learn mode directly should return 404
+    logger.step("GET /chapter/learn/... without plan")
+    response = auth_client.get(f'/chapter/learn/{topic_name}/0')
+    assert response.status_code == 404
+    assert b"Invalid step index" in response.data
+
+def test_chapter_mode_generates_plan_if_missing(auth_client, mocker, logger):
+    """Test that accessing the main chapter route generates a plan if missing."""
+    logger.section("test_chapter_mode_generates_plan_if_missing")
+    topic_name = "flashcard_only_topic"
+
+    # Initial topic data: no plan
+    topic_data_initial = {
+        "name": topic_name,
+        "plan": [],
+        "chapter_mode": [],
+        "flashcard_mode": [{"term": "Foo", "definition": "Bar"}]
+    }
+
+    # Mock load_topic to return initial data
+    mocker.patch('app.modes.chapter.routes.load_topic', return_value=topic_data_initial)
+
+    # Mock PlannerAgent to generate a plan
+    mocker.patch('app.common.agents.PlannerAgent.generate_study_plan', return_value=['Step 1', 'Step 2'])
+
+    # Mock save_topic
+    mock_save = mocker.patch('app.modes.chapter.routes.save_topic')
+
+    # Access /chapter/<topic>
+    logger.step(f"GET /chapter/{topic_name}")
+    response = auth_client.get(f'/chapter/{topic_name}')
+
+    # Should call planner
+    # Should save topic with new plan
+    assert mock_save.called
+    saved_data = mock_save.call_args[0][1]
+    assert saved_data['plan'] == ['Step 1', 'Step 2']
+
+    # Should redirect to learn mode
+    assert response.status_code == 302
+    assert response.headers['Location'] == f'/chapter/learn/{topic_name}/0'


### PR DESCRIPTION
This PR removes legacy commented-out code in `app/modes/chapter/routes.py` that was pending verification of issue #28. 

Verification was performed by adding a new test suite `tests/test_chapter_plan_handling.py` which confirms that:
1. Accessing the main chapter route (`/chapter/<topic_name>`) correctly generates a study plan if one is missing, ensuring the user is not left in a broken state.
2. Direct access to a specific step (`/chapter/learn/<topic_name>/<step_index>`) without a plan returns a 404, which is the expected behavior for invalid navigation.

This confirms that the original issue (handling topics without plans) is resolved by the auto-generation logic in the main route, and the specific redirection logic that was commented out is indeed no longer needed.

---
*PR created automatically by Jules for task [13466777146569011369](https://jules.google.com/task/13466777146569011369) started by @Rishabh-Bajpai*