### PR TITLE
Remove auto-fill of username in Full Name field

### DIFF
--- a/app/core/routes.py
+++ b/app/core/routes.py
@@ -251,7 +251,8 @@ def signup():
 
         uid = Login.generate_userid(inst_id)
 
-        new_login = Login(userid=uid, username=username, name=username, installation_id=inst_id)
+        # Removed auto-fill of name with username
+        new_login = Login(userid=uid, username=username, name='', installation_id=inst_id)
         new_login.set_password(password)
         db.session.add(new_login)
 


### PR DESCRIPTION
This change modifies the signup logic in `app/core/routes.py` to prevent the username from being automatically used as the full name.

**Changes:**
- `app/core/routes.py`: Initialize `Login` model with `name=''` instead of `name=username`.

**Verification:**
- Created a reproduction script `tests/reproduce_signup_issue.py` (deleted before submission) which confirmed that the name is now empty after signup.
- Ran `pytest tests/test_app.py` and all tests passed.

---
*PR created automatically by Jules for task [12131740203574144196](https://jules.google.com/task/12131740203574144196) started by @Rishabh-Bajpai*