### PR TITLE
Verify Chat Mode Route Implementation

### DIFF
--- a/tests/test_chat_redirection.py
+++ b/tests/test_chat_redirection.py
@@ -1,0 +1,28 @@
+import pytest
+from flask import url_for
+
+def test_chat_mode_redirection(client):
+    """Test that the chat mode redirection URL resolves correctly."""
+    # We use the test_request_context to test url_for without a full request
+    with client.application.test_request_context():
+        url = url_for('chat.mode', topic_name='test_topic')
+        assert url == '/chat/test_topic'
+
+def test_chat_mode_access(auth_client, mocker):
+    """Test accessing the chat mode route."""
+    topic_name = "test_chat_access"
+
+    # Mock dependencies to avoid actual DB/LLM calls
+    # Mock PlannerAgent
+    mocker.patch('app.modes.chat.routes.PlannerAgent.generate_study_plan', return_value=['Step 1'])
+
+    # Also mock ChatModeMainChatAgent for welcome message
+    mocker.patch('app.modes.chat.routes.ChatModeMainChatAgent.get_welcome_message', return_value="Welcome!")
+
+    mocker.patch('app.modes.chat.routes.load_topic', return_value={"name": topic_name})
+    mocker.patch('app.modes.chat.routes.save_topic')
+    mocker.patch('app.modes.chat.routes.save_chat_history')
+
+    response = auth_client.get(f'/chat/{topic_name}')
+    assert response.status_code == 200
+    assert b"Welcome!" in response.data


### PR DESCRIPTION
The task was to implement the Chat Mode route and fix a comment in `app/core/routes.py`.
Upon investigation, the `chat.mode` route was already implemented in `app/modes/chat/routes.py` and the stale comment was already removed from `app/core/routes.py`.
To ensure the route functions correctly and to prevent future regressions, I added a new test file `tests/test_chat_redirection.py` which verifies the route's existence and basic functionality.
All tests passed.

---
*PR created automatically by Jules for task [13939845383916710314](https://jules.google.com/task/13939845383916710314) started by @Rishabh-Bajpai*