### PR TITLE
Fix chat popup text and code overflow

### DIFF
--- a/app/common/static/css/chat_popup.css
+++ b/app/common/static/css/chat_popup.css
@@ -377,3 +377,66 @@ body:not(.dark-mode) .skeleton-line {
     opacity: 1 !important;
     cursor: wait;
 }
+
+/* Markdown Content Styling */
+.chat-message {
+    overflow-wrap: break-word; /* Ensure long words break */
+}
+
+.chat-message pre {
+    background-color: rgba(0, 0, 0, 0.05);
+    padding: 12px;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 10px 0;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    font-size: 0.9em;
+}
+
+body:not(.dark-mode) .chat-message pre {
+    background-color: #f8f9fa;
+    border-color: #e9ecef;
+}
+
+.chat-message code {
+    background-color: rgba(0, 0, 0, 0.1);
+    padding: 2px 5px;
+    border-radius: 4px;
+    font-family: 'Fira Code', 'Courier New', monospace;
+    font-size: 0.9em;
+}
+
+body:not(.dark-mode) .chat-message code {
+    background-color: #e9ecef;
+}
+
+/* Ensure pre inside code doesn't double pad */
+.chat-message pre code {
+    background-color: transparent;
+    padding: 0;
+    border-radius: 0;
+}
+
+/* General markdown styles */
+.chat-message p {
+    margin: 0 0 10px 0;
+}
+
+.chat-message p:last-child {
+    margin-bottom: 0;
+}
+
+.chat-message ul, .chat-message ol {
+    margin: 8px 0;
+    padding-left: 20px;
+}
+
+.chat-message li {
+    margin-bottom: 5px;
+}
+
+.chat-message h1, .chat-message h2, .chat-message h3, .chat-message h4 {
+    margin: 10px 0 8px 0;
+    font-size: 1.1em;
+    font-weight: 700;
+}


### PR DESCRIPTION
This PR fixes the issue where code blocks and long text strings were overflowing the chat popup bubble. It introduces specific CSS styles for `pre` and `code` elements to ensure they are contained within the message bubble and provide horizontal scrolling when necessary. It also adds consistent styling for other markdown elements to improve readability.

---
*PR created automatically by Jules for task [6445612286372746212](https://jules.google.com/task/6445612286372746212) started by @Rishabh-Bajpai*