### PR TITLE
Fix XSS vulnerabilities and CSS cleanup

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -29,6 +29,10 @@ def create_app(config_class=Config):
     app = Flask(__name__, template_folder='core/templates')
     app.config.from_object(config_class)
 
+    # Register Custom Filters
+    from app.common.utils import sanitize_html
+    app.jinja_env.filters['sanitize_html'] = sanitize_html
+
     # Initialize Flask extensions
     db.init_app(app)
     migrate.init_app(app, db)

--- a/app/common/static/css/chat_popup.css
+++ b/app/common/static/css/chat_popup.css
@@ -211,7 +211,6 @@
 }
 
 /* Message Bubbles */
-/* Message Bubbles */
 .chat-message {
     max-width: 85%;
     width: fit-content;
@@ -220,7 +219,6 @@
     font-size: 0.95rem;
     line-height: 1.5;
     position: relative;
-    word-wrap: break-word;
     overflow-wrap: break-word;
     white-space: normal; /* AI responses should collapse HTML whitespace */
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);

--- a/app/common/utils.py
+++ b/app/common/utils.py
@@ -8,6 +8,7 @@ import subprocess
 import logging
 import platform
 import psutil
+import bleach
 from datetime import datetime
 from dotenv import load_dotenv
 from app.core.exceptions import (
@@ -1070,3 +1071,32 @@ def _compare_versions(current_ver, release_data):
             "url": release_data["html_url"]
         }
     return None
+
+
+def sanitize_html(content):
+    """
+    Sanitize HTML content to prevent XSS.
+    Allowed tags and attributes can be customized.
+    """
+    if not content:
+        return ""
+
+    allowed_tags = [
+        'p', 'br', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+        'b', 'i', 'strong', 'em', 'u', 's', 'strike',
+        'code', 'pre', 'blockquote',
+        'table', 'thead', 'tbody', 'tr', 'th', 'td',
+        'span', 'div', 'img', 'a', 'hr',
+        'sup', 'sub'
+    ]
+
+    allowed_attributes = {
+        '*': ['class', 'title', 'id'],
+        'a': ['href', 'rel', 'target'],
+        'img': ['src', 'alt', 'width', 'height'],
+        'pre': ['data-lang'],
+        'code': ['class']
+    }
+
+    return bleach.clean(content, tags=allowed_tags, attributes=allowed_attributes, strip=True)

--- a/app/core/templates/notes.html
+++ b/app/core/templates/notes.html
@@ -63,7 +63,7 @@
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         initNotes({
-            topicName: "{{ topic.name | safe }}",
+            topicName: {{ topic.name | tojson }},
             csrfToken: "{{ csrf_token() }}",
             jweToken: "{{ jwe_token if jwe_token else '' }}"
         });

--- a/app/modes/chapter/templates/chapter/pdf_export.html
+++ b/app/modes/chapter/templates/chapter/pdf_export.html
@@ -23,7 +23,7 @@
     <h2>Average Score: {{ average_score }}%</h2>
     {% for step in topic.chapter_mode %}
     <h2>{{ topic.plan[loop.index0] }}</h2>
-    <div>{{ step.teaching_material | safe }}</div>
+    <div>{{ step.teaching_material | sanitize_html | safe }}</div>
     {% if step.questions %}
     <h3>Questions</h3>
     {% for question in step.questions.questions %}

--- a/app/modes/chat/templates/chat/mode.html
+++ b/app/modes/chat/templates/chat/mode.html
@@ -64,7 +64,7 @@
                     if message.role == 'user' else 'AI Tutor' }}</div>
                 <div class="message {{ 'user-message' if message.role == 'user' else 'assistant-message' }}">
                     <div class="message-content"></div>
-                    <div class="raw-markdown" style="display: none;">{{ message.content | safe }}</div>
+                    <div class="raw-markdown" style="display: none;">{{ message.content | sanitize_html | safe }}</div>
                 </div>
             </div>
             {% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "Authlib==1.4.0",
     "cryptography==42.0.5",
     "setuptools",
+    "bleach>=6.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_sanitization_integration.py
+++ b/tests/test_sanitization_integration.py
@@ -1,0 +1,44 @@
+import pytest
+from flask import Flask, render_template_string
+from app.common.utils import sanitize_html
+from config import Config
+
+def test_jinja_filter_registration():
+    """Test that sanitize_html is registered as a filter and works in templates."""
+    from app import create_app
+
+    # Create app with testing config
+    class TestConfig(Config):
+        TESTING = True
+        SECRET_KEY = 'test'
+        SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+        WTF_CSRF_ENABLED = False
+
+    app = create_app(TestConfig)
+
+    with app.test_request_context():
+        # Check if filter is in jinja_env
+        assert 'sanitize_html' in app.jinja_env.filters
+        assert app.jinja_env.filters['sanitize_html'] == sanitize_html
+
+        # Test rendering a template string
+        unsafe_content = "<script>alert(1)</script><b>Safe</b>"
+        template = "{{ content | sanitize_html | safe }}"
+        rendered = render_template_string(template, content=unsafe_content)
+
+        print(f"Rendered: {rendered}")
+        assert "<script>" not in rendered
+        assert "alert(1)" in rendered # strip=True removes tags, keeping content?
+        # bleach strip=True: <script>alert(1)</script> -> alert(1)
+        assert "<b>Safe</b>" in rendered
+
+        # Test 2: Unsafe attribute
+        unsafe_attr = "<img src=x onerror=alert(1)>"
+        template_attr = "{{ content | sanitize_html | safe }}"
+        rendered_attr = render_template_string(template_attr, content=unsafe_attr)
+        print(f"Rendered Attr: {rendered_attr}")
+        assert "onerror" not in rendered_attr
+        assert "src" in rendered_attr
+
+if __name__ == "__main__":
+    test_jinja_filter_registration()


### PR DESCRIPTION
Implemented HTML sanitization using `bleach` to address XSS vulnerabilities in templates rendering user/LLM content with `| safe`.
Specifically:
- `app/core/templates/notes.html`: Switched to `| tojson` for `topic.name` injection into JavaScript, preventing XSS in JS context.
- `app/modes/chapter/templates/chapter/pdf_export.html`: Applied `| sanitize_html` before `| safe`.
- `app/modes/chat/templates/chat/mode.html`: Applied `| sanitize_html` before `| safe`.

Also cleaned up `app/common/static/css/chat_popup.css` by removing a duplicate comment and the deprecated `word-wrap` property.

Verified with a new integration test ensuring the filter is registered and functional.

---
*PR created automatically by Jules for task [13618946442318885913](https://jules.google.com/task/13618946442318885913) started by @Rishabh-Bajpai*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTML content sanitization now applied to messages, notes, and exported PDFs to prevent unsafe content from being rendered.

* **Tests**
  * Added integration tests for content sanitization.

* **Chores**
  * Added bleach library as a project dependency.

* **Style**
  * Updated chat message text wrapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->