### PR TITLE
🔒 [security] Fix Hardcoded Secret Key Default in Configuration

### DIFF
--- a/app/common/config_validator.py
+++ b/app/common/config_validator.py
@@ -4,6 +4,7 @@ REQUIRED_VARS = [
     "LLM_BASE_URL",
     "LLM_MODEL_NAME",
     "DATABASE_URL",
+    "SECRET_KEY",
 ]
 
 

--- a/app/setup_app.py
+++ b/app/setup_app.py
@@ -1,6 +1,7 @@
 from flask import Flask, render_template, request
 import os
 import sys
+import secrets
 
 
 from flask_wtf.csrf import CSRFProtect
@@ -61,7 +62,8 @@ def create_setup_app():
                 'LLM_MAX_OUTPUT_TOKENS': request.form.get('llm_ctx', '20000'),
                 'TTS_BASE_URL': request.form.get('tts_url', ''),
                 'OPENAI_API_KEY': request.form.get('openai_key', ''),
-                'YOUTUBE_API_KEY': request.form.get('youtube_key', '')
+                'YOUTUBE_API_KEY': request.form.get('youtube_key', ''),
+                'SECRET_KEY': os.environ.get('SECRET_KEY') or secrets.token_hex(32)
             }
 
             # Simple validation

--- a/config.py
+++ b/config.py
@@ -45,7 +45,7 @@ def load_environment_variables():
 class Config:
     """Application configuration settings loaded from environment variables."""
 
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'dev-secret-key-change-in-production'
+    SECRET_KEY = os.environ.get('SECRET_KEY')
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or 'sqlite:///site.db'
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
@@ -73,5 +73,6 @@ class Config:
 class TestConfig(Config):
     """Configuration for running tests."""
     TESTING = True
+    SECRET_KEY = 'test-secret-key-for-unit-tests'
     SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
     WTF_CSRF_ENABLED = False


### PR DESCRIPTION
The application had a hardcoded default `SECRET_KEY` in `config.py`, which is a security risk as it could lead to session hijacking or CSRF bypass if not changed by the user.

This PR addresses the issue by:
1. Removing the insecure default from the main `Config` class.
2. Adding `SECRET_KEY` to the required configuration variables, ensuring the app won't run in an insecure state.
3. Automatically generating a cryptographically secure random key during the initial setup process and saving it to the `.env` file, providing a "secure by default" experience for the user.
4. Providing a dedicated test key in `TestConfig` to maintain test suite compatibility.

Verified the fix with a standalone script that confirms the new configuration logic and ensures `validate_config` correctly identifies missing keys.

---
*PR created automatically by Jules for task [1475574890268997092](https://jules.google.com/task/1475574890268997092) started by @Rishabh-Bajpai*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application configuration requirements to enforce security key management, with automatic generation available during setup if not explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->