### PR TITLE
⚡ Optimize Data Sync with eager loading (fixed N+1 queries)

### DIFF
--- a/app/common/dcs.py
+++ b/app/common/dcs.py
@@ -3,6 +3,7 @@ import requests
 import logging
 import threading
 import time
+from sqlalchemy.orm import joinedload
 from app.core.extensions import db
 from app.core.models import Installation, Topic, ChatMode, ChapterMode, QuizMode, FlashcardMode, User, TelemetryLog, Feedback, AIModelPerformance, PlanRevision, SyncLog
 
@@ -176,7 +177,7 @@ class DCSClient:
             # 2. Child Objects - Ensure Parent Topic is Included
 
             # ChatMode
-            chats = ChatMode.query.filter((ChatMode.sync_status == 'pending') | (ChatMode.sync_status is None)).limit(BATCH_SIZE).all()
+            chats = ChatMode.query.options(joinedload(ChatMode.topic)).filter((ChatMode.sync_status == 'pending') | (ChatMode.sync_status is None)).limit(BATCH_SIZE).all()
             for c in chats:
                 payload["chat_modes"].append({
                     "topic_id": c.topic_id,
@@ -194,7 +195,7 @@ class DCSClient:
                     add_topic_to_payload(c.topic)
 
             # ChapterMode
-            chapters = ChapterMode.query.filter((ChapterMode.sync_status == 'pending') | (ChapterMode.sync_status is None)).limit(BATCH_SIZE).all()
+            chapters = ChapterMode.query.options(joinedload(ChapterMode.topic)).filter((ChapterMode.sync_status == 'pending') | (ChapterMode.sync_status is None)).limit(BATCH_SIZE).all()
             for c in chapters:
                 payload["chapter_modes"].append({
                     "topic_id": c.topic_id,
@@ -216,7 +217,7 @@ class DCSClient:
                     add_topic_to_payload(c.topic)
 
             # QuizMode
-            quizzes = QuizMode.query.filter((QuizMode.sync_status == 'pending') | (QuizMode.sync_status is None)).limit(BATCH_SIZE).all()
+            quizzes = QuizMode.query.options(joinedload(QuizMode.topic)).filter((QuizMode.sync_status == 'pending') | (QuizMode.sync_status is None)).limit(BATCH_SIZE).all()
             for q in quizzes:
                 payload["quiz_modes"].append({
                     "topic_id": q.topic_id,
@@ -233,7 +234,7 @@ class DCSClient:
                     add_topic_to_payload(q.topic)
 
             # FlashcardMode
-            flashcards = FlashcardMode.query.filter((FlashcardMode.sync_status == 'pending') | (FlashcardMode.sync_status is None)).limit(BATCH_SIZE).all()
+            flashcards = FlashcardMode.query.options(joinedload(FlashcardMode.topic)).filter((FlashcardMode.sync_status == 'pending') | (FlashcardMode.sync_status is None)).limit(BATCH_SIZE).all()
             for f in flashcards:
                 payload["flashcard_modes"].append({
                     "topic_id": f.topic_id,
@@ -299,7 +300,7 @@ class DCSClient:
                 objects_to_update.append(f)
 
             # PlanRevision
-            plans = PlanRevision.query.filter((PlanRevision.sync_status == 'pending') | (PlanRevision.sync_status is None)).limit(BATCH_SIZE).all()
+            plans = PlanRevision.query.options(joinedload(PlanRevision.topic)).filter((PlanRevision.sync_status == 'pending') | (PlanRevision.sync_status is None)).limit(BATCH_SIZE).all()
             for pr in plans:
                 payload["plan_revisions"].append({
                     "topic_id": pr.topic_id,


### PR DESCRIPTION
💡 **What:** Implemented eager loading using `joinedload` for the `topic` relationship in several data synchronization loops within `app/common/dcs.py`.

🎯 **Why:** Previously, the `sync_data` method emitted a separate database query for each record's related `topic` in the `ChatMode`, `ChapterMode`, `QuizMode`, `FlashcardMode`, and `PlanRevision` loops (N+1 query problem). This was highly inefficient, especially when processing batches of 50 items.

📊 **Measured Improvement:**
While I was unable to run a live benchmark due to environment limitations (missing dependencies and no internet access), the optimization is a standard best practice in SQLAlchemy. By using a `LEFT OUTER JOIN` (via `joinedload`), we reduce the number of queries from $1 + N$ to $1$ for each mode's batch. For a full batch of 50 items across all 5 optimized modes, this could save up to 250 extra database queries per sync cycle.

---
*PR created automatically by Jules for task [12758710912737426360](https://jules.google.com/task/12758710912737426360) started by @Rishabh-Bajpai*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced database query performance for improved loading speed and responsiveness across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->