### PR TITLE
Fix toggleNotes ReferenceError in book view

### DIFF
--- a/app/templates/library/book_view.html
+++ b/app/templates/library/book_view.html
@@ -74,6 +74,7 @@
             alert("Failed to update status.");
             document.getElementById('shareToggle').checked = !isShared;
         }
+    }
     function toggleNotes() {
         const sidebar = document.getElementById('notesSidebar');
         sidebar.classList.toggle('collapsed');


### PR DESCRIPTION
Fixes a syntax error in `app/templates/library/book_view.html` where a missing closing brace caused `toggleNotes` to be undefined in the global scope. Verified with a reproduction script.

---
*PR created automatically by Jules for task [11281488349880055936](https://jules.google.com/task/11281488349880055936) started by @Rishabh-Bajpai*